### PR TITLE
fix(main.go): update installation steps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ generate: packr2
 HAS_PACKR2 := $(shell command -v packr2)
 packr2:
 ifndef HAS_PACKR2
-	$(GO) get -u github.com/gobuffalo/packr/v2/packr2
+	cd /tmp && $(GO) get github.com/gobuffalo/packr/v2/packr2@v2.6.0
 endif
 
 xbuild-all: generate

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ not the container should run as privileged or not:
 
 ```yaml
 required:
-  - docker
+  - docker:
       privileged: false
 ```
 

--- a/pkg/docker-compose/build.go
+++ b/pkg/docker-compose/build.go
@@ -8,14 +8,9 @@ const dockerComposeVersion = "1.26.0"
 
 // Build installs the docker and docker-compose binaries
 func (m *Mixin) Build() error {
-	dockerfileLines := fmt.Sprintf(`ENV DOCKER_VERSION="19.03.8"
-RUN apt-get update && apt-get install -y python3-pip wget && pip3 install --upgrade pip && \
-  wget https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz && \
-  tar -xvf docker-${DOCKER_VERSION}.tgz && \
-  mv docker/docker /usr/bin/docker && \
-  chmod +x /usr/bin/docker && \
-  rm -rf docker/ docker-${DOCKER_VERSION}.tgz && \
-  pip3 install docker-compose==%s`, dockerComposeVersion)
+	dockerfileLines := fmt.Sprintf(`RUN apt-get update && apt-get install -y curl && \
+curl -L "https://github.com/docker/compose/releases/download/%s/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && \
+chmod +x /usr/local/bin/docker-compose`, dockerComposeVersion)
 
 	fmt.Fprintln(m.Out, dockerfileLines)
 

--- a/pkg/docker-compose/build.go
+++ b/pkg/docker-compose/build.go
@@ -9,7 +9,7 @@ const dockerComposeVersion = "1.26.0"
 // Build installs the docker and docker-compose binaries
 func (m *Mixin) Build() error {
 	dockerfileLines := fmt.Sprintf(`RUN apt-get update && apt-get install -y curl && \
-curl -L "https://github.com/docker/compose/releases/download/%s/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && \
+curl -L "https://github.com/docker/compose/releases/download/%s/docker-compose-linux-x86_64" -o /usr/local/bin/docker-compose && \
 chmod +x /usr/local/bin/docker-compose`, dockerComposeVersion)
 
 	fmt.Fprintln(m.Out, dockerfileLines)

--- a/pkg/docker-compose/build_test.go
+++ b/pkg/docker-compose/build_test.go
@@ -8,14 +8,9 @@ import (
 )
 
 func TestMixin_Build(t *testing.T) {
-	const buildOutput = `ENV DOCKER_VERSION="19.03.8"
-RUN apt-get update && apt-get install -y python3-pip wget && pip3 install --upgrade pip && \
-  wget https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz && \
-  tar -xvf docker-${DOCKER_VERSION}.tgz && \
-  mv docker/docker /usr/bin/docker && \
-  chmod +x /usr/bin/docker && \
-  rm -rf docker/ docker-${DOCKER_VERSION}.tgz && \
-  pip3 install docker-compose==1.26.0
+	const buildOutput = `RUN apt-get update && apt-get install -y curl && \
+curl -L "https://github.com/docker/compose/releases/download/1.26.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && \
+chmod +x /usr/local/bin/docker-compose
 `
 
 	t.Run("build", func(t *testing.T) {

--- a/pkg/docker-compose/build_test.go
+++ b/pkg/docker-compose/build_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestMixin_Build(t *testing.T) {
 	const buildOutput = `RUN apt-get update && apt-get install -y curl && \
-curl -L "https://github.com/docker/compose/releases/download/1.26.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && \
+curl -L "https://github.com/docker/compose/releases/download/1.26.0/docker-compose-linux-x86_64" -o /usr/local/bin/docker-compose && \
 chmod +x /usr/local/bin/docker-compose
 `
 


### PR DESCRIPTION
* Updates installation steps per [official docs](https://docs.docker.com/compose/install/)
* Fixes typo in README.md

**Breaking Change**: this PR removes the installation of the docker CLI and focuses only on the docker-compose binary/cli.  My thinking was that if bundle authors need both, they'd use the https://github.com/getporter/docker-mixin for the former, which provides support for specifying an alternate docker CLI version.  What do we think?

Closes https://github.com/getporter/porter/issues/1663