### PR TITLE
fix(examples): update porter manifest per deprecation of tag field

### DIFF
--- a/examples/compose/porter.yaml
+++ b/examples/compose/porter.yaml
@@ -10,7 +10,7 @@
 name: compose
 version: 0.1.0
 description: A sample bundle using Docker Compose
-tag: getporter/docker-compose:v0.1.0
+registry: getporter
 
 required:
   - docker:


### PR DESCRIPTION
Closes https://github.com/getporter/docker-compose-mixin/issues/17