### PR TITLE
docs(README): add docker mixin mention; fix example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,27 @@ mixins:
     clientVersion: 1.26.0
 ```
 
+## Docker mixin
+
+This `docker-compose` mixin only adds the [docker-compose] CLI. However, the
+[docker] CLI will also most likely be required by bundles using Docker Compose.
+
+To add `docker`, you'll need to add the [Docker mixin] under the `mixins`
+section as well.
+
+```yaml
+mixins:
+- docker
+```
+
+For further details and configuration options for the Docker mixin, see the
+repo's [README][Docker mixin README].
+
+[docker-compose]: https://docs.docker.com/compose/reference/
+[docker]: https://docs.docker.com/engine/reference/commandline/cli/
+[Docker mixin]: https://github.com/getporter/docker-mixin
+[Docker mixin README]: https://github.com/getporter/docker-mixin#readme
+
 ## Required Extension
 
 To declare that Docker access is required to run the bundle, as will probably

--- a/examples/compose/porter.yaml
+++ b/examples/compose/porter.yaml
@@ -18,6 +18,7 @@ required:
 
 mixins:
   - docker-compose
+  - docker
 
 install:
   - docker-compose:


### PR DESCRIPTION
* Adds mention of the docker mixin to the README
* Fixes the 'compose' example bundle (docker mixin necessary)

Closes https://github.com/getporter/docker-compose-mixin/issues/28
Depends on https://github.com/getporter/docker-compose-mixin/pull/30 to pass CI