### PR TITLE
Reference latest changes in Porter's mixin publish logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 replace (
 	// common-magefile-functions
 	// https://github.com/getporter/porter/pull/1852
-	get.porter.sh/porter => github.com/carolynvs/porter v1.0.0-alpha.6.0.20220110193159-88e8c73c92f0
+	get.porter.sh/porter => github.com/carolynvs/porter v1.0.0-alpha.6.0.20220110200318-b48237d12b5c
 
 	// These are replace directives copied from porter
 	// They must match the replaces used by porter everything to compile

--- a/go.sum
+++ b/go.sum
@@ -225,8 +225,8 @@ github.com/carolynvs/datetime-printer v0.2.0/go.mod h1:p9W8ZUhmQUOVD5kiDuGXwRG65
 github.com/carolynvs/go-plugin v1.0.1-acceptstdin/go.mod h1:++UyYGoz3o5w9ZzAdZxtQKrWWP+iqPBn3cQptSMzBuY=
 github.com/carolynvs/magex v0.6.0 h1:rzz4RnBiR8hr2WYEsmq+mqkRLEstPnEK8ZP9MgxNY9Y=
 github.com/carolynvs/magex v0.6.0/go.mod h1:hqaEkr9TAv+kFb/5wgDiTdszF13rpe0Q+bWHmTe6N74=
-github.com/carolynvs/porter v1.0.0-alpha.6.0.20220110193159-88e8c73c92f0 h1:nS69Vqh2LQosjsKbO1TNL/yAgFrGibVuZ9O36zvBfPU=
-github.com/carolynvs/porter v1.0.0-alpha.6.0.20220110193159-88e8c73c92f0/go.mod h1:80GBW/48SSLNSCG8TW2kZ6O6e7fF5cl9vff06Ykg43I=
+github.com/carolynvs/porter v1.0.0-alpha.6.0.20220110200318-b48237d12b5c h1:kCuaFjxmgF/AdexRp2rWPXj5JjA68se8eolQBGJ9q5s=
+github.com/carolynvs/porter v1.0.0-alpha.6.0.20220110200318-b48237d12b5c/go.mod h1:80GBW/48SSLNSCG8TW2kZ6O6e7fF5cl9vff06Ykg43I=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e/go.mod h1:oDpT4efm8tSYHXV5tHSdRvBet/b/QzxZ+XyyPehvm3A=
 github.com/cbroglie/mustache v1.0.1 h1:ivMg8MguXq/rrz2eu3tw6g3b16+PQhoTn6EZAhst2mw=


### PR DESCRIPTION
This uses newer logic from the Porter PR https://github.com/getporter/porter/pull/1852:

* Do not use --author with git commit because git still wants an identity. Set the config file values directly on the command, e.g. -c user.name=x -c user.email=y to temporarily set those values.
