### PR TITLE
Don't install curl in bundle

### DIFF
--- a/pkg/docker-compose/build.go
+++ b/pkg/docker-compose/build.go
@@ -43,9 +43,7 @@ func (m *Mixin) Build(ctx context.Context) error {
 		dockerComposeVersion = dockerComposeDefaultVersion
 	}
 
-	dockerfileLines := fmt.Sprintf(`RUN apt-get update && apt-get install -y curl && \
-curl -fL "https://github.com/docker/compose/releases/download/v%s/docker-compose-linux-x86_64" -o /usr/local/bin/docker-compose && \
-chmod +x /usr/local/bin/docker-compose`, dockerComposeVersion)
+	dockerfileLines := fmt.Sprintf(`ADD --chmod=755 https://github.com/docker/compose/releases/download/v%s/docker-compose-linux-x86_64 /usr/local/bin/docker-compose`, dockerComposeVersion)
 
 	fmt.Fprintln(m.Out, dockerfileLines)
 

--- a/pkg/docker-compose/build_test.go
+++ b/pkg/docker-compose/build_test.go
@@ -11,9 +11,7 @@ import (
 )
 
 func TestMixin_Build(t *testing.T) {
-	const buildOutput = `RUN apt-get update && apt-get install -y curl && \
-curl -fL "https://github.com/docker/compose/releases/download/v2.10.2/docker-compose-linux-x86_64" -o /usr/local/bin/docker-compose && \
-chmod +x /usr/local/bin/docker-compose
+	const buildOutput = `ADD --chmod=755 https://github.com/docker/compose/releases/download/v2.10.2/docker-compose-linux-x86_64 /usr/local/bin/docker-compose
 `
 
 	t.Run("build", func(t *testing.T) {


### PR DESCRIPTION
### What does this change?

This replaces the `apt-get`, `curl` and `chmod` commands with a single Docker `ADD` instruction, which seems like a cleaner way of achieving the same result without installing curl into the resulting bundle.