### PR TITLE
Install as a Docker CLI plugin

### DIFF
--- a/pkg/docker-compose/build.go
+++ b/pkg/docker-compose/build.go
@@ -44,7 +44,7 @@ func (m *Mixin) Build(ctx context.Context) error {
 	}
 
 	dockerfileLines := fmt.Sprintf(`ADD --chmod=755 https://github.com/docker/compose/releases/download/v%s/docker-compose-linux-x86_64 /usr/local/lib/docker/cli-plugins/docker-compose
-RUN ln -s /usr/local/lib/docker/cli-plugins/docker-compose /usr/local/bin/docker-compose`, dockerComposeVersion)
+ENV PATH="$PATH:/usr/local/lib/docker/cli-plugins"`, dockerComposeVersion)
 
 	fmt.Fprintln(m.Out, dockerfileLines)
 

--- a/pkg/docker-compose/build.go
+++ b/pkg/docker-compose/build.go
@@ -44,8 +44,9 @@ func (m *Mixin) Build(ctx context.Context) error {
 	}
 
 	dockerfileLines := fmt.Sprintf(`RUN apt-get update && apt-get install -y curl && \
-curl -fL "https://github.com/docker/compose/releases/download/v%s/docker-compose-linux-x86_64" -o /usr/local/bin/docker-compose && \
-chmod +x /usr/local/bin/docker-compose`, dockerComposeVersion)
+    curl -fL "https://github.com/docker/compose/releases/download/v%s/docker-compose-linux-x86_64" -o /usr/local/lib/docker/cli-plugins/docker-compose --create-dirs && \
+    chmod +x /usr/local/lib/docker/cli-plugins/docker-compose && \
+    ln -s /usr/local/lib/docker/cli-plugins/docker-compose /usr/local/bin/docker-compose`, dockerComposeVersion)
 
 	fmt.Fprintln(m.Out, dockerfileLines)
 

--- a/pkg/docker-compose/build_test.go
+++ b/pkg/docker-compose/build_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestMixin_Build(t *testing.T) {
 	const buildOutput = `ADD --chmod=755 https://github.com/docker/compose/releases/download/v2.10.2/docker-compose-linux-x86_64 /usr/local/lib/docker/cli-plugins/docker-compose
-RUN ln -s /usr/local/lib/docker/cli-plugins/docker-compose /usr/local/bin/docker-compose
+ENV PATH="$PATH:/usr/local/lib/docker/cli-plugins"
 `
 
 	t.Run("build", func(t *testing.T) {

--- a/pkg/docker-compose/build_test.go
+++ b/pkg/docker-compose/build_test.go
@@ -12,8 +12,9 @@ import (
 
 func TestMixin_Build(t *testing.T) {
 	const buildOutput = `RUN apt-get update && apt-get install -y curl && \
-curl -fL "https://github.com/docker/compose/releases/download/v2.10.2/docker-compose-linux-x86_64" -o /usr/local/bin/docker-compose && \
-chmod +x /usr/local/bin/docker-compose
+    curl -fL "https://github.com/docker/compose/releases/download/v2.10.2/docker-compose-linux-x86_64" -o /usr/local/lib/docker/cli-plugins/docker-compose --create-dirs && \
+    chmod +x /usr/local/lib/docker/cli-plugins/docker-compose && \
+    ln -s /usr/local/lib/docker/cli-plugins/docker-compose /usr/local/bin/docker-compose
 `
 
 	t.Run("build", func(t *testing.T) {


### PR DESCRIPTION
### What does this change?

Installs the docker-compose binary to /usr/local/lib/docker/cli-plugins/ and symlinks /usr/local/bin/docker-compose to the new location. This allows using either `docker compose` or `docker-compose` in scripts. The motivation for this change is detailed in #47.

### What issue does it fix?

Closes #47

### Notes for the reviewer

I've tested this locally with the examples in the repo and my own bundle, it doesn't break the mixin commands nor scripts which use the `docker-compose` command.