### PR TITLE
Add up/down/pull commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ docker-compose:
       policy: missing
 ```
 
-This is equivilent to: `docker-compose --file compose.yml pull --ignore-pull-failures --policy missing serviceA serviceB`
+This is equivalent to: `docker-compose --file compose.yml pull --ignore-pull-failures --policy missing serviceA serviceB`
 
 ### Docker Compose Up
 
@@ -211,7 +211,7 @@ docker-compose:
       timeout: 30
 ```
 
-This is equivilent to: `docker-compose up --detach --timeout 30 serviceA serviceB`
+This is equivalent to: `docker-compose up --detach --timeout 30 serviceA serviceB`
 
 ### Docker Compose Down
 
@@ -224,7 +224,7 @@ docker-compose:
       timeout: 30
 ```
 
-This is equivilent to: `docker-compose down --remove-orphans --timeout 30`
+This is equivalent to: `docker-compose down --remove-orphans --timeout 30`
 
 See full bundle examples in the `examples` directory.
 

--- a/README.md
+++ b/README.md
@@ -153,11 +153,7 @@ outputs:
   path: /root/.kube/config
 ```
 
----
-
-## Examples
-
-### Docker Compose Up
+### Example
 
 ```yaml
 docker-compose:
@@ -169,17 +165,66 @@ docker-compose:
     timeout: 30
 ```
 
+## Mixin Commands
+
+This mixin has built-in support for common Docker Compose commands. Supported
+commands can be defined within the `docker-compose` step and support the same
+fields and options.
+
+Arguments and flags can be set on both the `docker-compose` step and on the
+specified sub-command. Arguments and flags set on the `docker-compose` step
+will be applied to the `docker-compose` part of the command while arguments
+and flags set on the sub-command will be applied to the sub-command.
+
+You may only specify one command within a single `docker-compose` step. To
+execute multiple commands, define multiple `docker-compose` steps.
+
+### Docker Compose Pull
+
+```yaml
+docker-compose:
+  description: Docker Compose Pull
+  flags:
+    file: compose.yml
+  pull:
+    arguments:
+      - serviceA
+      - serviceB
+    flags:
+      ignore-pull-failures:
+      policy: missing
+```
+
+This is equivilent to: `docker-compose --file compose.yml pull --ignore-pull-failures --policy missing serviceA serviceB`
+
+### Docker Compose Up
+
+```yaml
+docker-compose:
+  description: Docker Compose Up
+  up:
+    arguments:
+      - serviceA
+      - serviceB
+    flags:
+      detach:
+      timeout: 30
+```
+
+This is equivilent to: `docker-compose up --detach --timeout 30 serviceA serviceB`
+
 ### Docker Compose Down
 
 ```yaml
 docker-compose:
-  description: "Docker Compose Down"
-  arguments:
-    - down
-    - --remove-orphans
-  flags:
-    timeout: 30
+  description: Docker Compose Down
+  down:
+    flags:
+      remove-orphans:
+      timeout: 30
 ```
+
+This is equivilent to: `docker-compose down --remove-orphans --timeout 30`
 
 See full bundle examples in the `examples` directory.
 

--- a/cmd/docker-compose/main.go
+++ b/cmd/docker-compose/main.go
@@ -54,7 +54,7 @@ func main() {
 func buildRootCommand(m *dockercompose.Mixin, in io.Reader) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:  "docker-compose",
-		Long: "A skeleton mixin to use for building other mixins for porter 👩🏽‍✈️",
+		Long: "Use the Docker Compose CLI with Porter",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			// Enable swapping out stdout/stderr for testing
 			m.In = in

--- a/examples/compose/porter.yaml
+++ b/examples/compose/porter.yaml
@@ -24,9 +24,9 @@ mixins:
 install:
   - docker-compose:
       description: Docker Compose up
-      arguments:
-        - up
-        - -d
+      up:
+        flags:
+          detach:
 
 ps:
   - docker-compose:
@@ -37,6 +37,6 @@ ps:
 uninstall:
   - docker-compose:
       description: Docker Compose down
-      arguments:
-        - down
-        - --remove-orphans
+      down:
+        flags:
+          remove-orphans:

--- a/examples/dockervolume/porter.yaml
+++ b/examples/dockervolume/porter.yaml
@@ -28,9 +28,9 @@ install:
 
   - docker-compose:
       description: "Docker Compose Up"
-      arguments:
-        - up
-        - -d
+      up:
+        flags:
+          detach:
 
   - exec:
       description: "Print app logs"
@@ -47,9 +47,9 @@ upgrade:
 
   - docker-compose:
       description: "Docker Compose Up"
-      arguments:
-        - up
-        - -d
+      up:
+        flags:
+          detach:
 
   - exec:
       description: "Print app logs"
@@ -60,8 +60,7 @@ upgrade:
 uninstall:
   - docker-compose:
       description: "Docker Compose Down"
-      arguments:
-        - down
+      down:
 
   - exec:
       description: "Remove Docker Volume"

--- a/pkg/docker-compose/action.go
+++ b/pkg/docker-compose/action.go
@@ -1,6 +1,7 @@
 package dockercompose
 
 import (
+	"get.porter.sh/mixin/docker-compose/pkg/docker-compose/commands"
 	"get.porter.sh/porter/pkg/exec/builder"
 )
 
@@ -49,71 +50,5 @@ func (a Action) GetSteps() []builder.ExecutableStep {
 }
 
 type Step struct {
-	Instruction `yaml:"docker-compose"`
-}
-
-var _ builder.ExecutableStep = Step{}
-var _ builder.StepWithOutputs = Step{}
-var _ builder.SuppressesOutput = Step{}
-
-type Instruction struct {
-	Name             string        `yaml:"name"`
-	Description      string        `yaml:"description"`
-	Arguments        []string      `yaml:"arguments,omitempty"`
-	Flags            builder.Flags `yaml:"flags,omitempty"`
-	Outputs          []Output      `yaml:"outputs,omitempty"`
-	SuppressOutput   bool          `yaml:"suppress-output,omitempty"`
-	WorkingDirectory string        `yaml:"dir,omitempty"`
-}
-
-func (s Step) GetCommand() string {
-	return "docker-compose"
-}
-
-func (s Step) GetArguments() []string {
-	return s.Arguments
-}
-
-func (s Step) GetFlags() builder.Flags {
-	return s.Flags
-}
-
-func (s Step) GetWorkingDir() string {
-	return s.WorkingDirectory
-}
-
-func (s Step) GetOutputs() []builder.Output {
-	// Go doesn't have generics, nothing to see here...
-	outputs := make([]builder.Output, len(s.Outputs))
-	for i := range s.Outputs {
-		outputs[i] = s.Outputs[i]
-	}
-	return outputs
-}
-
-func (s Step) SuppressesOutput() bool {
-	return s.SuppressOutput
-}
-
-var _ builder.OutputJsonPath = Output{}
-var _ builder.OutputFile = Output{}
-
-type Output struct {
-	Name string `yaml:"name"`
-
-	// See https://porter.sh/mixins/exec/#outputs
-	JsonPath string `yaml:"jsonPath,omitempty"`
-	FilePath string `yaml:"path,omitempty"`
-}
-
-func (o Output) GetName() string {
-	return o.Name
-}
-
-func (o Output) GetJsonPath() string {
-	return o.JsonPath
-}
-
-func (o Output) GetFilePath() string {
-	return o.FilePath
+	commands.ComposeCommand `yaml:"docker-compose"`
 }

--- a/pkg/docker-compose/action.go
+++ b/pkg/docker-compose/action.go
@@ -3,6 +3,7 @@ package dockercompose
 import (
 	"get.porter.sh/mixin/docker-compose/pkg/docker-compose/commands"
 	"get.porter.sh/porter/pkg/exec/builder"
+	"gopkg.in/yaml.v3"
 )
 
 var _ builder.ExecutableAction = Action{}
@@ -51,4 +52,60 @@ func (a Action) GetSteps() []builder.ExecutableStep {
 
 type Step struct {
 	commands.ComposeCommand `yaml:"docker-compose"`
+}
+
+// UnmarshalYAML takes any yaml in this form
+//
+//	docker-compose:
+//	  description: something
+//	  COMMAND: # e.g. pull/up/down -> make the PullCommand/UpCommand/DownCommand for us
+func (s *Step) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	// Turn the yaml into a raw map so we can iterate over the values and
+	// look for which command was used
+	stepMap := map[string]map[string]interface{}{}
+	err := unmarshal(&stepMap)
+	if err != nil {
+		return err
+	}
+
+	// Get at the values defined under "docker-compose"
+	composeStep := stepMap["docker-compose"]
+	b, err := yaml.Marshal(composeStep)
+	if err != nil {
+		return err
+	}
+	err = yaml.Unmarshal(b, &s.ComposeCommand)
+	if err != nil {
+		return err
+	}
+
+	// Turn the command into its typed data structure
+	for key, value := range composeStep {
+		var cmd commands.Command
+
+		switch key {
+		case "down":
+			cmd = &commands.DownCommand{}
+		case "pull":
+			cmd = &commands.PullCommand{}
+		case "up":
+			cmd = &commands.UpCommand{}
+		default:
+			continue
+		}
+
+		b, err = yaml.Marshal(value)
+		if err != nil {
+			return err
+		}
+		err = yaml.Unmarshal(b, cmd)
+		if err != nil {
+			return err
+		}
+
+		s.Subcommand = &cmd
+		break // There is only 1 command
+	}
+
+	return nil
 }

--- a/pkg/docker-compose/action_test.go
+++ b/pkg/docker-compose/action_test.go
@@ -34,9 +34,21 @@ func TestMixin_UnmarshalStep(t *testing.T) {
 			"Supressed Surprise", []string{"surprise", "me"}, nil, nil, nil, true,
 		},
 		{
+			"down", "testdata/commands/down-input.yaml", "Compose Down", nil,
+			builder.Flags{builder.NewFlag("file", "test.yml")},
+			[]string{"down", "--remove-orphans", "--timeout", "25", "serviceA", "serviceB"},
+			[]commands.Output{{Name: "containerId", JsonPath: "$Id"}}, false,
+		},
+		{
 			"pull", "testdata/commands/pull-input.yaml", "Compose Pull", nil,
 			builder.Flags{builder.NewFlag("file", "test.yml")},
 			[]string{"pull", "--ignore-pull-failures", "--policy", "missing", "serviceA", "serviceB"},
+			[]commands.Output{{Name: "containerId", JsonPath: "$Id"}}, false,
+		},
+		{
+			"up", "testdata/commands/up-input.yaml", "Compose Up", nil,
+			builder.Flags{builder.NewFlag("file", "test.yml")},
+			[]string{"up", "--detach", "--timeout", "25", "serviceA", "serviceB"},
 			[]commands.Output{{Name: "containerId", JsonPath: "$Id"}}, false,
 		},
 	}

--- a/pkg/docker-compose/action_test.go
+++ b/pkg/docker-compose/action_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"get.porter.sh/mixin/docker-compose/pkg/docker-compose/commands"
 	"get.porter.sh/porter/pkg/exec/builder"
 
 	"github.com/stretchr/testify/assert"
@@ -23,7 +24,7 @@ func TestMixin_UnmarshalStep(t *testing.T) {
 	step := action.Steps[0]
 	assert.Equal(t, "Compose Up", step.Description)
 	assert.NotEmpty(t, step.Outputs)
-	assert.Equal(t, Output{Name: "containerId", JsonPath: "$Id"}, step.Outputs[0])
+	assert.Equal(t, commands.Output{Name: "containerId", JsonPath: "$Id"}, step.Outputs[0])
 
 	require.Len(t, step.Arguments, 2)
 	assert.Equal(t, "up", step.Arguments[0])

--- a/pkg/docker-compose/commands/command.go
+++ b/pkg/docker-compose/commands/command.go
@@ -1,0 +1,31 @@
+package commands
+
+import "get.porter.sh/porter/pkg/exec/builder"
+
+type Command interface {
+	builder.ExecutableStep
+	builder.HasOrderedArguments
+	builder.StepWithOutputs
+	builder.SuppressesOutput
+}
+
+var _ builder.OutputJsonPath = Output{}
+var _ builder.OutputFile = Output{}
+
+type Output struct {
+	Name     string `yaml:"name"`
+	JsonPath string `yaml:"jsonPath,omitempty"`
+	FilePath string `yaml:"path,omitempty"`
+}
+
+func (o Output) GetName() string {
+	return o.Name
+}
+
+func (o Output) GetJsonPath() string {
+	return o.JsonPath
+}
+
+func (o Output) GetFilePath() string {
+	return o.FilePath
+}

--- a/pkg/docker-compose/commands/compose.go
+++ b/pkg/docker-compose/commands/compose.go
@@ -1,0 +1,47 @@
+package commands
+
+import "get.porter.sh/porter/pkg/exec/builder"
+
+var _ Command = ComposeCommand{}
+
+type ComposeCommand struct {
+	Description      string        `yaml:"description"`
+	WorkingDirectory string        `yaml:"dir,omitempty"`
+	Arguments        []string      `yaml:"arguments,omitempty"`
+	Flags            builder.Flags `yaml:"flags,omitempty"`
+	Outputs          []Output      `yaml:"outputs,omitempty"`
+	SuppressOutput   bool          `yaml:"suppress-output,omitempty"`
+}
+
+func (c ComposeCommand) GetCommand() string {
+	return "docker-compose"
+}
+
+func (c ComposeCommand) GetArguments() []string {
+	return c.Arguments
+}
+
+func (c ComposeCommand) GetFlags() builder.Flags {
+	return c.Flags
+}
+
+func (c ComposeCommand) GetSuffixArguments() []string {
+	return nil
+}
+
+func (c ComposeCommand) GetOutputs() []builder.Output {
+	// Go doesn't have generics, nothing to see here...
+	outputs := make([]builder.Output, len(c.Outputs))
+	for i := range c.Outputs {
+		outputs[i] = c.Outputs[i]
+	}
+	return outputs
+}
+
+func (c ComposeCommand) SuppressesOutput() bool {
+	return c.SuppressOutput
+}
+
+func (c ComposeCommand) GetWorkingDir() string {
+	return c.WorkingDirectory
+}

--- a/pkg/docker-compose/commands/compose.go
+++ b/pkg/docker-compose/commands/compose.go
@@ -11,6 +11,7 @@ type ComposeCommand struct {
 	Flags            builder.Flags `yaml:"flags,omitempty"`
 	Outputs          []Output      `yaml:"outputs,omitempty"`
 	SuppressOutput   bool          `yaml:"suppress-output,omitempty"`
+	Subcommand       *PullCommand  `yaml:"pull,omitempty"`
 }
 
 func (c ComposeCommand) GetCommand() string {
@@ -26,7 +27,24 @@ func (c ComposeCommand) GetFlags() builder.Flags {
 }
 
 func (c ComposeCommand) GetSuffixArguments() []string {
-	return nil
+	// Final Command: docker-compose ARGS FLAGS [CMD CMD_ARGS CMD_FLAGS CMD_SUFFIX_ARGS]
+	// We need to return: CMD CMD_ARGS CMD_FLAGS CMD_SUFFIX_ARGS
+	if c.Subcommand == nil {
+		return nil
+	}
+
+	cmd := (*c.Subcommand).GetCommand()
+	cmdArgs := (*c.Subcommand).GetArguments()
+	cmdFlags := (*c.Subcommand).GetFlags()
+	cmdSuffixArgs := (*c.Subcommand).GetSuffixArguments()
+
+	suffixArgs := make([]string, 0, 1+len(cmdArgs)+(len(cmdFlags)*2)+len(cmdSuffixArgs))
+	suffixArgs = append(suffixArgs, cmd)
+	suffixArgs = append(suffixArgs, cmdArgs...)
+	suffixArgs = append(suffixArgs, cmdFlags.ToSlice(builder.DefaultFlagDashes)...)
+	suffixArgs = append(suffixArgs, cmdSuffixArgs...)
+
+	return suffixArgs
 }
 
 func (c ComposeCommand) GetOutputs() []builder.Output {
@@ -35,11 +53,18 @@ func (c ComposeCommand) GetOutputs() []builder.Output {
 	for i := range c.Outputs {
 		outputs[i] = c.Outputs[i]
 	}
+	if c.Subcommand != nil {
+		outputs = append(outputs, (*c.Subcommand).GetOutputs()...)
+	}
 	return outputs
 }
 
 func (c ComposeCommand) SuppressesOutput() bool {
-	return c.SuppressOutput
+	if c.Subcommand != nil && (*c.Subcommand).SuppressesOutput() {
+		return true
+	} else {
+		return c.SuppressOutput
+	}
 }
 
 func (c ComposeCommand) GetWorkingDir() string {

--- a/pkg/docker-compose/commands/compose.go
+++ b/pkg/docker-compose/commands/compose.go
@@ -11,7 +11,7 @@ type ComposeCommand struct {
 	Flags            builder.Flags `yaml:"flags,omitempty"`
 	Outputs          []Output      `yaml:"outputs,omitempty"`
 	SuppressOutput   bool          `yaml:"suppress-output,omitempty"`
-	Subcommand       *PullCommand  `yaml:"pull,omitempty"`
+	Subcommand       *Command
 }
 
 func (c ComposeCommand) GetCommand() string {

--- a/pkg/docker-compose/commands/down.go
+++ b/pkg/docker-compose/commands/down.go
@@ -1,0 +1,46 @@
+package commands
+
+import "get.porter.sh/porter/pkg/exec/builder"
+
+var _ Command = DownCommand{}
+
+type DownCommand struct {
+	Arguments      []string      `yaml:"arguments,omitempty"`
+	Flags          builder.Flags `yaml:"flags,omitempty"`
+	Outputs        []Output      `yaml:"outputs,omitempty"`
+	SuppressOutput bool          `yaml:"suppress-output,omitempty"`
+}
+
+func (c DownCommand) GetCommand() string {
+	return "down"
+}
+
+func (c DownCommand) GetArguments() []string {
+	// Always use suffix arguments
+	return nil
+}
+
+func (c DownCommand) GetFlags() builder.Flags {
+	return c.Flags
+}
+
+func (c DownCommand) GetSuffixArguments() []string {
+	return c.Arguments
+}
+
+func (c DownCommand) GetOutputs() []builder.Output {
+	// Go doesn't have generics, nothing to see here...
+	outputs := make([]builder.Output, len(c.Outputs))
+	for i := range c.Outputs {
+		outputs[i] = c.Outputs[i]
+	}
+	return outputs
+}
+
+func (c DownCommand) SuppressesOutput() bool {
+	return c.SuppressOutput
+}
+
+func (c DownCommand) GetWorkingDir() string {
+	return "."
+}

--- a/pkg/docker-compose/commands/pull.go
+++ b/pkg/docker-compose/commands/pull.go
@@ -1,0 +1,46 @@
+package commands
+
+import "get.porter.sh/porter/pkg/exec/builder"
+
+var _ Command = PullCommand{}
+
+type PullCommand struct {
+	Arguments      []string      `yaml:"arguments,omitempty"`
+	Flags          builder.Flags `yaml:"flags,omitempty"`
+	Outputs        []Output      `yaml:"outputs,omitempty"`
+	SuppressOutput bool          `yaml:"suppress-output,omitempty"`
+}
+
+func (c PullCommand) GetCommand() string {
+	return "pull"
+}
+
+func (c PullCommand) GetArguments() []string {
+	// Always use suffix arguments
+	return nil
+}
+
+func (c PullCommand) GetFlags() builder.Flags {
+	return c.Flags
+}
+
+func (c PullCommand) GetSuffixArguments() []string {
+	return c.Arguments
+}
+
+func (c PullCommand) GetOutputs() []builder.Output {
+	// Go doesn't have generics, nothing to see here...
+	outputs := make([]builder.Output, len(c.Outputs))
+	for i := range c.Outputs {
+		outputs[i] = c.Outputs[i]
+	}
+	return outputs
+}
+
+func (c PullCommand) SuppressesOutput() bool {
+	return c.SuppressOutput
+}
+
+func (c PullCommand) GetWorkingDir() string {
+	return "."
+}

--- a/pkg/docker-compose/commands/up.go
+++ b/pkg/docker-compose/commands/up.go
@@ -1,0 +1,46 @@
+package commands
+
+import "get.porter.sh/porter/pkg/exec/builder"
+
+var _ Command = UpCommand{}
+
+type UpCommand struct {
+	Arguments      []string      `yaml:"arguments,omitempty"`
+	Flags          builder.Flags `yaml:"flags,omitempty"`
+	Outputs        []Output      `yaml:"outputs,omitempty"`
+	SuppressOutput bool          `yaml:"suppress-output,omitempty"`
+}
+
+func (c UpCommand) GetCommand() string {
+	return "up"
+}
+
+func (c UpCommand) GetArguments() []string {
+	// Always use suffix arguments
+	return nil
+}
+
+func (c UpCommand) GetFlags() builder.Flags {
+	return c.Flags
+}
+
+func (c UpCommand) GetSuffixArguments() []string {
+	return c.Arguments
+}
+
+func (c UpCommand) GetOutputs() []builder.Output {
+	// Go doesn't have generics, nothing to see here...
+	outputs := make([]builder.Output, len(c.Outputs))
+	for i := range c.Outputs {
+		outputs[i] = c.Outputs[i]
+	}
+	return outputs
+}
+
+func (c UpCommand) SuppressesOutput() bool {
+	return c.SuppressOutput
+}
+
+func (c UpCommand) GetWorkingDir() string {
+	return "."
+}

--- a/pkg/docker-compose/execute_test.go
+++ b/pkg/docker-compose/execute_test.go
@@ -27,6 +27,10 @@ func TestMixin_Execute(t *testing.T) {
 			"install", "testdata/install-input.yaml", "",
 			"docker-compose up --build --scale 2",
 		},
+		{
+			"pull", "testdata/commands/pull-input.yaml", "containerId",
+			"docker-compose --file test.yml pull --ignore-pull-failures --policy missing serviceA serviceB",
+		},
 	}
 
 	for _, tc := range testcases {

--- a/pkg/docker-compose/execute_test.go
+++ b/pkg/docker-compose/execute_test.go
@@ -28,8 +28,16 @@ func TestMixin_Execute(t *testing.T) {
 			"docker-compose up --build --scale 2",
 		},
 		{
+			"down", "testdata/commands/down-input.yaml", "containerId",
+			"docker-compose --file test.yml down --remove-orphans --timeout 25 serviceA serviceB",
+		},
+		{
 			"pull", "testdata/commands/pull-input.yaml", "containerId",
 			"docker-compose --file test.yml pull --ignore-pull-failures --policy missing serviceA serviceB",
+		},
+		{
+			"up", "testdata/commands/up-input.yaml", "containerId",
+			"docker-compose --file test.yml up --detach --timeout 25 serviceA serviceB",
 		},
 	}
 

--- a/pkg/docker-compose/schema/schema.json
+++ b/pkg/docker-compose/schema/schema.json
@@ -103,8 +103,44 @@
           "description": "Do not print output from the command",
           "type": "boolean"
         },
+        "down": {
+          "description": "Stop and remove containers, networks",
+          "type": "object",
+          "properties": {
+            "arguments": {
+              "$ref": "#/definitions/docker-compose/properties/arguments"
+            },
+            "flags": {
+              "$ref": "#/definitions/docker-compose/properties/flags"
+            },
+            "outputs": {
+              "$ref": "#/definitions/docker-compose/properties/outputs"
+            },
+            "suppress-output": {
+              "$ref": "#/definitions/docker-compose/properties/suppress-output"
+            }
+          }
+        },
         "pull": {
           "description": "Pull service images",
+          "type": "object",
+          "properties": {
+            "arguments": {
+              "$ref": "#/definitions/docker-compose/properties/arguments"
+            },
+            "flags": {
+              "$ref": "#/definitions/docker-compose/properties/flags"
+            },
+            "outputs": {
+              "$ref": "#/definitions/docker-compose/properties/outputs"
+            },
+            "suppress-output": {
+              "$ref": "#/definitions/docker-compose/properties/suppress-output"
+            }
+          }
+        },
+        "up": {
+          "description": "Create and start containers",
           "type": "object",
           "properties": {
             "arguments": {

--- a/pkg/docker-compose/schema/schema.json
+++ b/pkg/docker-compose/schema/schema.json
@@ -102,6 +102,24 @@
         "suppress-output": {
           "description": "Do not print output from the command",
           "type": "boolean"
+        },
+        "pull": {
+          "description": "Pull service images",
+          "type": "object",
+          "properties": {
+            "arguments": {
+              "$ref": "#/definitions/docker-compose/properties/arguments"
+            },
+            "flags": {
+              "$ref": "#/definitions/docker-compose/properties/flags"
+            },
+            "outputs": {
+              "$ref": "#/definitions/docker-compose/properties/outputs"
+            },
+            "suppress-output": {
+              "$ref": "#/definitions/docker-compose/properties/suppress-output"
+            }
+          }
         }
       },
       "additionalProperties": false

--- a/pkg/docker-compose/schema_test.go
+++ b/pkg/docker-compose/schema_test.go
@@ -37,6 +37,7 @@ func TestMixin_ValidateSchema(t *testing.T) {
 		{"invoke", "testdata/invoke-input.yaml", ""},
 		{"uninstall", "testdata/uninstall-input.yaml", ""},
 		{"invalid property", "testdata/invalid-input.yaml", "Additional property args is not allowed"},
+		{"pull", "testdata/commands/pull-input.yaml", ""},
 	}
 
 	for _, tc := range testcases {

--- a/pkg/docker-compose/schema_test.go
+++ b/pkg/docker-compose/schema_test.go
@@ -37,7 +37,9 @@ func TestMixin_ValidateSchema(t *testing.T) {
 		{"invoke", "testdata/invoke-input.yaml", ""},
 		{"uninstall", "testdata/uninstall-input.yaml", ""},
 		{"invalid property", "testdata/invalid-input.yaml", "Additional property args is not allowed"},
+		{"down", "testdata/commands/down-input.yaml", ""},
 		{"pull", "testdata/commands/pull-input.yaml", ""},
+		{"up", "testdata/commands/up-input.yaml", ""},
 	}
 
 	for _, tc := range testcases {

--- a/pkg/docker-compose/testdata/commands/down-input.yaml
+++ b/pkg/docker-compose/testdata/commands/down-input.yaml
@@ -1,0 +1,15 @@
+action:
+  - docker-compose:
+      description: Compose Down
+      flags:
+        file: test.yml
+      down:
+        arguments:
+          - serviceA
+          - serviceB
+        flags:
+          remove-orphans:
+          timeout: 25
+        outputs:
+          - name: containerId
+            jsonPath: $Id

--- a/pkg/docker-compose/testdata/commands/pull-input.yaml
+++ b/pkg/docker-compose/testdata/commands/pull-input.yaml
@@ -1,0 +1,15 @@
+action:
+  - docker-compose:
+      description: Compose Pull
+      flags:
+        file: test.yml
+      pull:
+        arguments:
+          - serviceA
+          - serviceB
+        flags:
+          ignore-pull-failures:
+          policy: missing
+        outputs:
+          - name: containerId
+            jsonPath: $Id

--- a/pkg/docker-compose/testdata/commands/up-input.yaml
+++ b/pkg/docker-compose/testdata/commands/up-input.yaml
@@ -1,0 +1,15 @@
+action:
+  - docker-compose:
+      description: Compose Up
+      flags:
+        file: test.yml
+      up:
+        arguments:
+          - serviceA
+          - serviceB
+        flags:
+          detach:
+          timeout: 25
+        outputs:
+          - name: containerId
+            jsonPath: $Id


### PR DESCRIPTION
### What does this change?

Initial design and structure for adding docker-compose commands as first-class fields. This PR includes pull/up/down as proof of concept, but this can easily be extended to other commands in a follow-on PR.

These commands use the same YAML syntax as the main `docker-compose` field for defining arguments and flags. For example:

```yaml
docker-compose:
  description: Pull services
  flags:
    file: compose.yml
  pull:
    arguments:
      - serviceA
      - serviceB
    flags:
      ignore-pull-failures:
```

This is equivalent to `docker-compose --file compose.yml pull --ignore-pull-failures serviceA serviceB`.

However, custom fields for each command could be added in the future (with appropriate defaults) without breaking backwards compatibility, allowing for a more concise and natural syntax as suggested in https://github.com/getporter/docker-compose-mixin/issues/3#issuecomment-886222995

### What issue does it fix?

Partially implements #3, though more work is needed to flesh it out.

### Notes for the reviewer

This is not a breaking change, the existing mixin syntax can still be used and works as expected.

I've updated the tests and examples to use the new syntax.

### Checklist

- [x] Did you write tests?
- [x] Did you write documentation?
- [x] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

[contributors]: https://porter.sh/src/CONTRIBUTORS.md
